### PR TITLE
fix: update sidebar buttons for RuneLite FlatLaf

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Current mistakes being tracked:
 
 ## Changes
 
+#### 1.5
+
+* Update Side Panel for RuneLite's new Look and Feel (FlatLaf)
+
 #### 1.4
 
 * Various bug fixes to Akkha's "Quadrant Special":

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.toamistaketracker'
-version = '1.4'
+version = '1.5'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/toamistaketracker/panel/ToaMistakeTrackerPanel.java
+++ b/src/main/java/com/toamistaketracker/panel/ToaMistakeTrackerPanel.java
@@ -147,9 +147,8 @@ public class ToaMistakeTrackerPanel extends PluginPanel {
         leftTitleContainer.add(currentViewTitle, BorderLayout.WEST);
 
         // Create the switch view button
-        SwingUtil.removeButtonDecorations(switchMistakesViewBtn);
         switchMistakesViewBtn.setText(getSwitchMistakesViewButtonText());
-        switchMistakesViewBtn.setBackground(Color.WHITE);
+        switchMistakesViewBtn.setBackground(Color.DARK_GRAY);
         switchMistakesViewBtn.setBorder(new EmptyBorder(10, 10, 10, 10));
         switchMistakesViewBtn.setBorderPainted(true);
         switchMistakesViewBtn.setPreferredSize(new Dimension(100, 10));
@@ -158,13 +157,11 @@ public class ToaMistakeTrackerPanel extends PluginPanel {
         switchMistakesViewBtn.addActionListener(e -> switchMistakesView());
         switchMistakesViewBtn.addMouseListener(new MouseAdapter() {
             public void mouseEntered(MouseEvent e) {
-                switchMistakesViewBtn.setForeground(Color.LIGHT_GRAY);
-                switchMistakesViewBtn.setBackground(Color.LIGHT_GRAY);
+                switchMistakesViewBtn.setBackground(Color.GRAY);
             }
 
             public void mouseExited(MouseEvent e) {
-                switchMistakesViewBtn.setForeground(Color.WHITE);
-                switchMistakesViewBtn.setBackground(Color.WHITE);
+                switchMistakesViewBtn.setBackground(Color.DARK_GRAY);
             }
         });
 


### PR DESCRIPTION
Updates the button color that switches the Mistakes View to be properly visible with RuneLite's new Look and Feel (FlatLaf).

Fixes QuestingPet/ToaMistakeTracker#10